### PR TITLE
Feature/int 962

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ This will toggle whether or not to search the ServiceNow's Asset Table with stri
 A comma separated list of Fields to query against Incidents. 
 > NOTE: If a field is not in this list, it will not be searched on on in ServiceNow's Incident Table.
 > (This applies to IP Addresses, Domains, and String searches)
-      
+
+### Enable Asset Search
+If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP Addresses, Domains, CVEs and annotated entities.
+
 ### Asset Query Fields
 A comma separated list of fields to search domains and IPs by in ServiceNow's Asset Table.
 > NOTE: If a field is not in this list, it will not be searched on in ServiceNow's Asset Table.

--- a/config/config.js
+++ b/config/config.js
@@ -150,7 +150,7 @@ module.exports = {
       description:
         'A comma separated list of Fields to query against Incidents.  \n' +
         'NOTE: If a field is not in this list, it will not be searched on Incident Queries.\n' +
-        '(This applies to IP Addresses, Domains, and String searches)',
+        '(This applies to IP address, domain, and annotated entity searches)',
       default: 'u_ip_addr_2, u_destination_ip, short_description, work_notes',
       type: 'text',
       userCanEdit: false,

--- a/config/config.js
+++ b/config/config.js
@@ -160,7 +160,7 @@ module.exports = {
       key: 'enableAssetSearch',
       name: 'Enable Asset Search',
       description:
-          "If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP addresses, domains, and annotated entities.",
+          "If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP Addresses, Domains, CVEs and annotated entities",
       default: true,
       type: 'boolean',
       userCanEdit: false,

--- a/config/config.js
+++ b/config/config.js
@@ -25,7 +25,7 @@ module.exports = {
    */
   description:
     'ServiceNow automates and streamlines work and helps create great employee and customer experiences.',
-  entityTypes: ['IPv4', 'email', 'domain', 'string'],
+  entityTypes: ['IPv4', 'email', 'domain', 'string', 'cve'],
   customTypes: [
     {
       key: 'incident',
@@ -113,8 +113,8 @@ module.exports = {
         'The URL of the ServiceNow instance to connect to including the schema (i.e., https://)',
       default: '',
       type: 'text',
-      userCanEdit: true,
-      adminOnly: false
+      userCanEdit: false,
+      adminOnly: true
     },
     {
       key: 'username',
@@ -122,8 +122,8 @@ module.exports = {
       description: 'The username to login to ServiceNow with',
       default: '',
       type: 'text',
-      userCanEdit: true,
-      adminOnly: false
+      userCanEdit: false,
+      adminOnly: true
     },
     {
       key: 'password',
@@ -131,18 +131,18 @@ module.exports = {
       description: 'The password to login to ServiceNow with',
       default: '',
       type: 'password',
-      userCanEdit: true,
-      adminOnly: false
+      userCanEdit: false,
+      adminOnly: true
     },
     {
       key: 'shouldSearchString',
       name: 'Search By Annotated Entities',
       description:
-        "This will toggle whether or not to search the ServiceNow's Asset Table with annotated entities found in your channels.",
+        "This will toggle whether or not to search the ServiceNow for annotated entities found in your channels.",
       default: false,
       type: 'boolean',
-      userCanEdit: true,
-      adminOnly: false
+      userCanEdit: false,
+      adminOnly: true
     },
     {
       key: 'incidentQueryFields',
@@ -153,20 +153,30 @@ module.exports = {
         '(This applies to IP Addresses, Domains, and String searches)',
       default: 'u_ip_addr_2, u_destination_ip, short_description, work_notes',
       type: 'text',
-      userCanEdit: true,
-      adminOnly: false
+      userCanEdit: false,
+      adminOnly: true
+    },
+    {
+      key: 'enableAssetSearch',
+      name: 'Enable Asset Search',
+      description:
+          "If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP addresses, domains, and annotated entities.",
+      default: true,
+      type: 'boolean',
+      userCanEdit: false,
+      adminOnly: true
     },
     {
       key: 'assetTableFields',
       name: 'Asset Query Fields',
       description:
         "A comma separated list of fields to search domains and IPs by in ServiceNow's Asset Table.  \n" +
-        "NOTE: If a field is not in this list, it will not be searched on for in ServiceNow's Asset Table.\n" +
+        "NOTE: If a field is not in this list, the field will not be searched in ServiceNow's Asset Table.\n" +
         '(This applies to IP Addresses, Domains, and String searches)',
       default: 'dns_domain, sys_domain_path, ip_address, short_description',
       type: 'text',
-      userCanEdit: true,
-      adminOnly: false
+      userCanEdit: false,
+      adminOnly: true
     }
   ]
 };

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,13 @@
   "acronym": "SN",
   "defaultColor": "light-purple",
   "description": "ServiceNow automates and streamlines work and helps create great employee and customer experiences.",
-  "entityTypes": ["IPv4", "email", "domain", "string"],
+  "entityTypes": [
+    "IPv4",
+    "email",
+    "domain",
+    "string",
+    "cve"
+  ],
   "customTypes": [
     {
       "key": "incident",
@@ -26,7 +32,9 @@
       "regex": "RITM[0-9]{7,}"
     }
   ],
-  "styles": ["./styles/styles.less"],
+  "styles": [
+    "./styles/styles.less"
+  ],
   "block": {
     "component": {
       "file": "./components/block.js"
@@ -53,8 +61,8 @@
       "description": "The URL of the ServiceNow instance to connect to including the schema (i.e., https://)",
       "default": "",
       "type": "text",
-      "userCanEdit": true,
-      "adminOnly": false
+      "userCanEdit": false,
+      "adminOnly": true
     },
     {
       "key": "username",
@@ -62,8 +70,8 @@
       "description": "The username to login to ServiceNow with",
       "default": "",
       "type": "text",
-      "userCanEdit": true,
-      "adminOnly": false
+      "userCanEdit": false,
+      "adminOnly": true
     },
     {
       "key": "password",
@@ -71,26 +79,35 @@
       "description": "The password to login to ServiceNow with",
       "default": "",
       "type": "password",
-      "userCanEdit": true,
-      "adminOnly": false
+      "userCanEdit": false,
+      "adminOnly": true
     },
     {
       "key": "shouldSearchString",
       "name": "Search By Annotated Entities",
-      "description": "This will toggle whether or not to search the ServiceNow's Asset Table with annotated entities found in your channels.",
+      "description": "This will toggle whether or not to search the ServiceNow for annotated entities found in your channels.",
       "default": false,
       "type": "boolean",
-      "userCanEdit": true,
-      "adminOnly": false
+      "userCanEdit": false,
+      "adminOnly": true
     },
     {
       "key": "incidentQueryFields",
       "name": "Incident Query Fields",
-      "description": "A comma separated list of Fields to query against Incidents.  \nNOTE: If a field is not in this list, it will not be searched on Incident Queries.\n(This applies to IP Addresses, Domains, and String searches)",
+      "description": "A comma separated list of Fields to query against Incidents.  \nNOTE: If a field is not in this list, it will not be searched on Incident Queries.\n(This applies to IP address, domain, and annotated entity searches)",
       "default": "u_ip_addr_2, u_destination_ip, short_description, work_notes",
       "type": "text",
-      "userCanEdit": true,
-      "adminOnly": false
+      "userCanEdit": false,
+      "adminOnly": true
+    },
+    {
+      "key": "enableAssetSearch",
+      "name": "Enable Asset Search",
+      "description": "If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP addresses, domains, and annotated entities.",
+      "default": true,
+      "type": "boolean",
+      "userCanEdit": false,
+      "adminOnly": true
     },
     {
       "key": "assetTableFields",
@@ -98,8 +115,8 @@
       "description": "A comma separated list of fields to search domains and IPs by in ServiceNow's Asset Table.  \nNOTE: If a field is not in this list, it will not be searched on for in ServiceNow's Asset Table.\n(This applies to IP Addresses, Domains, and String searches)",
       "default": "dns_domain, sys_domain_path, ip_address, short_description",
       "type": "text",
-      "userCanEdit": true,
-      "adminOnly": false
+      "userCanEdit": false,
+      "adminOnly": true
     }
   ]
 }

--- a/config/config.json
+++ b/config/config.json
@@ -3,14 +3,7 @@
   "acronym": "SN",
   "defaultColor": "light-purple",
   "description": "ServiceNow automates and streamlines work and helps create great employee and customer experiences.",
-  "entityTypes": [
-    "IPv4",
-    "email",
-    "domain",
-    "string",
-    "cve"
-  ],
-  "customTypes": [
+  "entityTypes": ["IPv4", "email", "domain", "string", "cve"],"customTypes": [
     {
       "key": "incident",
       "regex": "INC[0-9]{7,}"
@@ -32,16 +25,10 @@
       "regex": "RITM[0-9]{7,}"
     }
   ],
-  "styles": [
-    "./styles/styles.less"
-  ],
+  "styles": ["./styles/styles.less"],
   "block": {
-    "component": {
-      "file": "./components/block.js"
-    },
-    "template": {
-      "file": "./templates/block.hbs"
-    }
+    "component": { "file": "./components/block.js" },
+    "template": { "file": "./templates/block.hbs" }
   },
   "request": {
     "cert": "",
@@ -51,9 +38,7 @@
     "proxy": "",
     "rejectUnauthorized": true
   },
-  "logging": {
-    "level": "info"
-  },
+  "logging": { "level": "info" },
   "options": [
     {
       "key": "url",
@@ -103,7 +88,7 @@
     {
       "key": "enableAssetSearch",
       "name": "Enable Asset Search",
-      "description": "If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP addresses, domains, and annotated entities.",
+      "description": "If checked, the integration will search ServiceNow's Asset Table (alm_asset) for IP Addresses, Domains, CVEs and annotated entities",
       "default": true,
       "type": "boolean",
       "userCanEdit": false,
@@ -112,7 +97,7 @@
     {
       "key": "assetTableFields",
       "name": "Asset Query Fields",
-      "description": "A comma separated list of fields to search domains and IPs by in ServiceNow's Asset Table.  \nNOTE: If a field is not in this list, it will not be searched on for in ServiceNow's Asset Table.\n(This applies to IP Addresses, Domains, and String searches)",
+      "description": "A comma separated list of fields to search domains and IPs by in ServiceNow's Asset Table.  \nNOTE: If a field is not in this list, the field will not be searched in ServiceNow's Asset Table.\n(This applies to IP Addresses, Domains, and String searches)",
       "default": "dns_domain, sys_domain_path, ip_address, short_description",
       "type": "text",
       "userCanEdit": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "service-now",
-  "version": "3.3.7-beta",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-now",
-  "version": "3.3.7-beta",
+  "version": "3.4.0",
   "main": "./integration.js",
   "private": true,
   "license": "MIT",

--- a/src/dataTransformations.js
+++ b/src/dataTransformations.js
@@ -38,6 +38,8 @@ const groupEntities = (entities) =>
         ? 'sha1'
         : type === 'SHA256'
         ? 'sha256'
+        : type === 'cve'
+        ? 'cve'
         : 'unknown'
     )
     .omit('unknown')

--- a/src/displayStructures/assets.js
+++ b/src/displayStructures/assets.js
@@ -7,6 +7,7 @@ const ASSET_DISPLAY_STRUCTURE = [
     isDisplayLink: true
   },
   { label: 'Asset Name', path: 'name' },
+  { label: 'Display Name', path: 'display_name' },
   { label: 'Asset Subcategory', path: 'subcategory' },
   { label: 'Serial Number', path: 'serial_number' },
   { label: 'Asset Tag', path: 'asset_tag' },
@@ -15,7 +16,25 @@ const ASSET_DISPLAY_STRUCTURE = [
   { label: 'Asset Sub-Warranty Expires On', path: 'warranty_expiration', isDate: true },
   { label: 'Asset Operating System', path: 'os' },
   { label: 'Asset Delivered On', path: 'delivery_date', isDate: true },
-  { label: 'PO Number', path: 'po_number' }
+  { label: 'PO Number', path: 'po_number' },
+  { label: 'Comments', path: 'comments' },
+
+  {
+    isTitle: true,
+    label: 'Assigned To',
+    path: 'assigned_to.link',
+    icon: 'user',
+    isDisplayLink: true,
+    pathIsLinkToMoreData: true,
+    moreDataDisplayStructure: 'sys_user'
+  },
+  {
+    label: 'Department',
+    path: 'department.link',
+    pathIsLinkToMoreData: true,
+    moreDataLinkType: 'cmn_department',
+    pathToOnePropertyFromMoreDataToDisplay: 'name'
+  },
 ];
 
 module.exports = ASSET_DISPLAY_STRUCTURE;

--- a/src/displayStructures/knowledgeBase.js
+++ b/src/displayStructures/knowledgeBase.js
@@ -7,14 +7,28 @@ const KNOWLEDGE_BASE_DISPLAY_STRUCTURE = [
     isDisplayLink: true
   },
   { label: 'Number', path: 'number' },
-  { label: 'Author', path: 'author' },
   { label: 'Topic', path: 'topic' },
-  { label: 'Category', path: 'kb_category' },
+  {
+    label: 'Category',
+    path: 'kb_category.link',
+    pathIsLinkToMoreData: true,
+    moreDataLinkType: 'kb_category',
+    pathToOnePropertyFromMoreDataToDisplay: 'full_category'
+  },
   { label: 'Description', path: 'short_description' },
-  { label: 'Create By', path: 'sys_created_by' },
-  { label: 'Create On', path: 'sys_created_on', isDate: true },
+  { label: 'Created By', path: 'sys_created_by' },
+  { label: 'Created On', path: 'sys_created_on', isDate: true },
   { label: 'Updated By', path: 'sys_updated_by' },
-  { label: 'Updated On', path: 'sys_updated_on', isDate: true }
+  { label: 'Updated On', path: 'sys_updated_on', isDate: true },
+  {
+    isTitle: true,
+    label: 'Author',
+    path: 'author.link',
+    icon: 'user',
+    isDisplayLink: true,
+    pathIsLinkToMoreData: true,
+    moreDataDisplayStructure: 'sys_user'
+  },
 ];
 
 module.exports = KNOWLEDGE_BASE_DISPLAY_STRUCTURE;

--- a/src/functionalityByEntityType/assetsAndIncidentCustomFunctionality.js
+++ b/src/functionalityByEntityType/assetsAndIncidentCustomFunctionality.js
@@ -15,7 +15,7 @@ const {
 
 const assetsAndIncidentCustomFunctionality = {
   queryFunction: async (entity, options, requestWithDefaults, Logger) => ({
-    ...(await queryAssets(entity, options, requestWithDefaults, Logger)),
+    ...(options.enableAssetSearch ? await queryAssets(entity, options, requestWithDefaults, Logger) : {}),
     ...(await queryTableData(entity, options, requestWithDefaults, Logger))
   }),
   tableQueryQueryString: ({ value }, { incidentQueryFields }) =>

--- a/src/functionalityByEntityType/customFunctionalityByType.js
+++ b/src/functionalityByEntityType/customFunctionalityByType.js
@@ -72,6 +72,7 @@ const CUSTOM_FUNCTIONALITY_FOR_STANDARD_ENTITY_TYPES = {
   IPv4: assetsAndIncidentCustomFunctionality,
   domain: assetsAndIncidentCustomFunctionality,
   string: assetsAndIncidentCustomFunctionality,
+  cve: assetsAndIncidentCustomFunctionality,
   email: {
     tableQueryTableName: 'sys_user',
     tableQueryQueryString: ({ value }) => `email=${value}`,

--- a/src/querying/queryAssets.js
+++ b/src/querying/queryAssets.js
@@ -7,17 +7,20 @@ const queryAssets = async (entity, options, requestWithDefaults, Logger) => {
       get('assetTableFields'),
       split(','),
       map((field) => `${trim(field)}CONTAINS${entity.value}`),
-      join('^OR')
+      join('^NQ')
     )(options);
 
-    const assetsData = getOr(
-      [],
-      'body.records',
-      await requestWithDefaults({
-        uri: `${options.url}/cmdb_ci_list.do?JSONv2=&displayvalue=true&sysparm_query=${assetTableQuery}&sysparm_limit=10`,
-        options
-      })
-    );
+    const requestOptions = {
+      uri: `${options.url}/api/now/table/alm_asset`,
+      qs: {
+        sysparm_query: assetTableQuery,
+        sysparm_limit: 10
+      },
+      options
+    };
+
+    const response = await requestWithDefaults(requestOptions);
+    const assetsData = getOr([], 'body.result', response);
 
     if (!size(assetsData)) return;
 

--- a/src/querying/queryKnowledgeBase.js
+++ b/src/querying/queryKnowledgeBase.js
@@ -5,15 +5,19 @@ const queryKnowledgeBase = async (entity, options, requestWithDefaults, Logger) 
   try {
     const knowledgeBaseData = getOr(
       [],
-      'body.records',
+      'body.result',
       await requestWithDefaults({
-        uri: `${options.url}/kb_knowledge_list.do?JSONv2=&displayvalue=true&sysparm_query=numberCONTAINS${entity.value}`,
+        uri: `${options.url}/api/now/table/kb_knowledge`,
+        qs: {
+          sysparm_query: `numberCONTAINS${entity.value}`,
+          sysparm_limit: 10
+        },
         options
       })
     );
 
     if (!size(knowledgeBaseData)) return;
-    
+
     return {
       knowledgeBaseData: map(
         (kbItem) => ({


### PR DESCRIPTION
@penwoodjon Would love it if you could give this a look over given the complexity of ServiceNow

1. Adds CVE support (was super easy to do!)
2. Fixes asset lookups.  The old way was using a private API.  This now uses the table API which is "official" and switches to the `^NQ` operator to OR the search fields together.  I believe the previous use of `^OR` was causing the issue of too many non-relevant results coming back.
3. Improves knowledge base lookups by switching over to the official table API to do the search
4. Added an option to turn off asset searches in case a user doesn't want to search assets at all
5. Default options to be admin only